### PR TITLE
FIX: write() must be str, not bytes

### DIFF
--- a/svgo-inkscape/svgo.inkscape.py
+++ b/svgo-inkscape/svgo.inkscape.py
@@ -67,7 +67,7 @@ class SvgoInkscape (inkex.Effect):
 
         result = os.popen(command).read()
 
-        sys.stdout.write(result.encode("UTF-8"))
+        sys.stdout.write(result)
         sys.stdout.close()
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #8 on Windows, don't know how it will behave on other platforms.